### PR TITLE
Fix: #76 actualTimer에 종료 콜백함수 추가

### DIFF
--- a/NoMyeolmang/NoMyeolmang/Sources/Service/ActualTimerManager.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Service/ActualTimerManager.swift
@@ -16,11 +16,13 @@ final class ActualTimerManager {
     private var timer: Timer?
     private var interval: TimeInterval = 1.0
     private var isRepeating: Bool = true
-    private var count: Int = 0
     private var goalTime: Int = 300
+    var count: Int = 0
 
     // 타이머 이벤트 알림
     var onTick: ((Int) -> Void)?
+
+    var onFinish: (() -> Void)?
 
     // MARK: Public Methods
     func start(interval: TimeInterval = 1.0, repeats: Bool = true) {
@@ -29,6 +31,9 @@ final class ActualTimerManager {
         self.interval = interval
         self.isRepeating = repeats
         self.count = 0
+        
+        // 🔹 타이머 시작 직전에 즉시 1회 호출
+        self.onTick?(self.count)
 
         timer = Timer.scheduledTimer(
             withTimeInterval: interval,
@@ -37,6 +42,11 @@ final class ActualTimerManager {
                 guard let self else { return }
                 self.count += 1
                 self.onTick?(self.count)
+
+                if self.count >= self.goalTime {
+                    self.onFinish?()
+                    self.stop()
+                }
             }
         )
     }
@@ -44,7 +54,7 @@ final class ActualTimerManager {
     func stop() {
         clear()
     }
-    
+
     func setGoalTime(newGoalTime: Int) {
         self.goalTime = newGoalTime
         print(self.goalTime)
@@ -53,11 +63,11 @@ final class ActualTimerManager {
     var isRunning: Bool {
         return timer?.isValid ?? false
     }
-    
+
     var lastingTime: Int {
         return goalTime - count
     }
-    
+
     // MARK: Private Methods
     private func clear() {
         timer?.invalidate()

--- a/NoMyeolmang/NoMyeolmang/Sources/Service/ActualTimerManager.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Service/ActualTimerManager.swift
@@ -30,7 +30,6 @@ final class ActualTimerManager {
 
         self.interval = interval
         self.isRepeating = repeats
-        self.count = 0
         
         // 🔹 타이머 시작 직전에 즉시 1회 호출
         self.onTick?(self.count)
@@ -70,6 +69,7 @@ final class ActualTimerManager {
 
     // MARK: Private Methods
     private func clear() {
+        self.count = 0
         timer?.invalidate()
         timer = nil
     }

--- a/NoMyeolmang/NoMyeolmang/Sources/Service/VirtualTimerManager.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Service/VirtualTimerManager.swift
@@ -16,7 +16,7 @@ final class VirtualTimerManager {
     private var timer: Timer?
     private var interval: TimeInterval = 1.0
     private var isRepeating: Bool = true
-    private var count: Int = 0
+    var count: Int = 0
 
     // 타이머 이벤트 알림
     var onTick: ((Int) -> Void)?

--- a/NoMyeolmang/NoMyeolmang/Sources/Service/VirtualTimerManager.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Service/VirtualTimerManager.swift
@@ -27,7 +27,6 @@ final class VirtualTimerManager {
 
         self.interval = interval
         self.isRepeating = repeats
-        self.count = 0
 
         timer = Timer.scheduledTimer(
             withTimeInterval: interval,
@@ -59,6 +58,7 @@ final class VirtualTimerManager {
 
     // MARK: Private Methods
     private func clear() {
+        self.count = 0
         timer?.invalidate()
         timer = nil
     }


### PR DESCRIPTION
## ✨ 작업 내용
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #76 

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->
- onFinish 함수 추가
- 테스트 코드 추가 ([API문서](https://www.notion.so/posacademy/TimerManager-2372b843d5af807a8360daa6cdb1dc11?source=copy_link)에 작성)

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->
<img width="400" height="300" alt="스크린샷 2025-07-26 오전 1 40 05" src="https://github.com/user-attachments/assets/0bc7a8a7-932c-4a0a-9f5c-35c87eaf26aa" />



---

## ✅ 체크리스트

예시)
- [ ] 관련 이슈를 닫는 커밋 메시지 사용 (`Closes #`)
- [ ] 동작 확인 완료 (시뮬레이터 / 실기기)
- [ ] PR 제목, 설명 명확히 작성됨
- [ ] 커밋 메시지 규칙 준수
- [ ] 불필요한 주석/코드 제거

---

## 💬 리뷰 포인트
<!-- 로직 고민, UI 구성, 네이밍 등 의견 요청 -->
테스트코드 한번 돌려보시고 이상한 부분 있으면 리뷰 남겨주세요!
일단 뷰모델 안짜고 그냥 onAppear, onChange로 테스트해봤을 때는 잘 굴러갔어요
1. 뷰를 켜자마자 타이머가 불러와서 시작되는지
2. 이전뷰/다음뷰에서 이동하면 시간 초기화가 잘 되는지
3. 집중력 타이머가 따로 잘 카운팅 되고 있는지
위의 세가지는 체크를 했는데 또 다른 경우 발견되면 댓글 부탁드립니다!