### PR TITLE
Fix: #101 타이머가 종료될 때 count 정보가 초기화되는 버그 수정

### DIFF
--- a/NoMyeolmang/NoMyeolmang/Sources/Service/ActualTimerManager.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Service/ActualTimerManager.swift
@@ -30,6 +30,7 @@ final class ActualTimerManager {
 
         self.interval = interval
         self.isRepeating = repeats
+        self.count = 0
         
         // 🔹 타이머 시작 직전에 즉시 1회 호출
         self.onTick?(self.count)
@@ -69,7 +70,6 @@ final class ActualTimerManager {
 
     // MARK: Private Methods
     private func clear() {
-        self.count = 0
         timer?.invalidate()
         timer = nil
     }

--- a/NoMyeolmang/NoMyeolmang/Sources/Service/VirtualTimerManager.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Service/VirtualTimerManager.swift
@@ -27,6 +27,7 @@ final class VirtualTimerManager {
 
         self.interval = interval
         self.isRepeating = repeats
+        self.count = 0
 
         timer = Timer.scheduledTimer(
             withTimeInterval: interval,
@@ -58,7 +59,6 @@ final class VirtualTimerManager {
 
     // MARK: Private Methods
     private func clear() {
-        self.count = 0
         timer?.invalidate()
         timer = nil
     }


### PR DESCRIPTION
## ✨ 작업 내용
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #101

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->
ActualTimer와 VirtualTimer 모두 해당
- stop() 함수의 self.count = 0 초기화 삭제
- start() 함수의 시작에 self.count = 0 초기화 추가

## ✅ 체크리스트

예시)
- [ ] 관련 이슈를 닫는 커밋 메시지 사용 (`Closes #`)
- [ ] 동작 확인 완료 (시뮬레이터 / 실기기)
- [ ] PR 제목, 설명 명확히 작성됨
- [ ] 커밋 메시지 규칙 준수
- [ ] 불필요한 주석/코드 제거

---

## 💬 리뷰 포인트
<!-- 로직 고민, UI 구성, 네이밍 등 의견 요청 -->
간단한 수정만 했습니다!