### PR TITLE
Fix: #112 timerSettingView 누락 수정 및 Personalizater 생성 위치 수정

### DIFF
--- a/NoMyeolmang/NoMyeolmang/Sources/App/RootView.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/App/RootView.swift
@@ -13,16 +13,19 @@ struct RootView: View {
     @AppStorage("hasSeenOnboarding") private var hasSeenOnboarding = false
 
     private let predictor = FocusScorePredictor(model: ModelLoader.loadModel()!)
+    private var personalizater = FocusPersonalizater(modelURL: ModelLoader.loadModelURL())
     private var repository: UserTrainingDataRepository {
         SwiftDataUserTrainingDataRepository(context: context)
     }
-
+    
     var body: some View {
         if hasSeenOnboarding {
             NavigationStack(path: $coordinator.path) {
                 TimerSettingView()
                     .navigationDestination(for: AppRoute.self) { route in
                         switch route {
+                        case .timerSetting:
+                            TimerSettingView()
                         case .timer:
                             TimerView(
                                 viewModel: TimerViewModel(
@@ -34,13 +37,11 @@ struct RootView: View {
                             FeedbackView(
                                 viewModel: FeedbackViewModel(
                                     repository: repository,
-                                    personalizater: FocusPersonalizater(modelURL: ModelLoader.loadModelURL())
+                                    personalizater: personalizater
                                 )
                             )
                         case .report:
                             ReportView(viewModel: ReportViewModel())
-                        default:
-                            EmptyView()
                         }
                     }
             }


### PR DESCRIPTION
## 📌 PR 제목 형식
[타입] 간단한 설명 (ex. [Feat] 로그인 페이지 레이아웃 구현)

## ✨ 작업 내용
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #112

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 타이머세팅뷰 루트에 추가했습니다.
- Personalizater 인스턴스 생성 위치 변경(정확히는 loadModel 불러오는 위치)

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

---

## ✅ 체크리스트

예시)
- [x]  관련 이슈를 닫는 커밋 메시지 사용 (`Closes #`)
- [x] 동작 확인 완료 (시뮬레이터 / 실기기)
- [x] PR 제목, 설명 명확히 작성됨
- [x] 커밋 메시지 규칙 준수
- [x] 불필요한 주석/코드 제거

---

## 💬 리뷰 포인트
<!-- 로직 고민, UI 구성, 네이밍 등 의견 요청 -->

잠결이라... 한번 검토해주시고 어프로브!