### PR TITLE
Fix: #135 타이머 세팅 뷰 수정사항 반영

### DIFF
--- a/NoMyeolmang/NoMyeolmang/Sources/Presentation/TimerSettingView/View/PersonalTimerSettingView.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Presentation/TimerSettingView/View/PersonalTimerSettingView.swift
@@ -10,9 +10,17 @@ import Foundation
 import SwiftUI
 
 struct PersonalTimerSettingView: View {
+    @ObservedObject var viewModel: TimerSettingViewModel
     @Binding var goalTime: Int
     @State private var newGoalTimeText: String = ""
     @FocusState private var isTextFieldFocused: Bool
+
+    var isValidInput: Bool {
+        if let time = Int(newGoalTimeText) {
+            return (10...30).contains(time)
+        }
+        return false
+    }
 
     var body: some View {
         let boxSize = CGSize(width: 329, height: 161)
@@ -39,8 +47,18 @@ struct PersonalTimerSettingView: View {
                             } else if digitsOnly != newGoalTimeText {
                                 newGoalTimeText = digitsOnly
                             }
-                            if let time = Int(newGoalTimeText) {
+
+                            if let time = Int(newGoalTimeText), (10...30).contains(time) {
                                 goalTime = time
+                            } else {
+                                goalTime = 0
+                            }
+
+                            viewModel.validateGoalTime()
+                        }
+                        .onSubmit {
+                            if !isValidInput {
+                                newGoalTimeText = ""
                             }
                         }
                         .multilineTextAlignment(.center)
@@ -49,14 +67,27 @@ struct PersonalTimerSettingView: View {
                         .textFieldStyle(PlainTextFieldStyle())
                         .focused($isTextFieldFocused)
                         .onAppear {
-                            goalTime = 0
-                            newGoalTimeText = ""
+                            if viewModel.selectedTab == .personal {
+                                newGoalTimeText = ""
+                                goalTime = 0
+                            } else {
+                                newGoalTimeText = "\(goalTime)"
+                            }
+
+                            viewModel.validateGoalTime()
                             isTextFieldFocused = true
+                        }
+                        .onChange(of: viewModel.selectedTab) { newValue in
+                            if newValue == .personal {
+                                newGoalTimeText = ""
+                                goalTime = 0
+                                viewModel.validateGoalTime()
+                            }
                         }
                         .frame(minWidth: 20, minHeight: 32)
                         .fixedSize()
 
-                    if Int(newGoalTimeText) != nil {
+                    if !newGoalTimeText.isEmpty {
                         Text("분")
                             .textStyle(GSFont.SemiBold24)
                             .foregroundColor(.white)
@@ -89,7 +120,7 @@ struct PersonalTimerSettingView: View {
         @State private var goalTime = 30
         
         var body: some View {
-            PersonalTimerSettingView(goalTime: $goalTime)
+            PersonalTimerSettingView(viewModel: TimerSettingViewModel(), goalTime: $goalTime)
         }
     }
     

--- a/NoMyeolmang/NoMyeolmang/Sources/Presentation/TimerSettingView/View/PersonalTimerSettingView.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Presentation/TimerSettingView/View/PersonalTimerSettingView.swift
@@ -33,11 +33,13 @@ struct PersonalTimerSettingView: View {
                 HStack(alignment: .firstTextBaseline, spacing: 0) {
                     TextField("", text: $newGoalTimeText)
                         .onChange(of: newGoalTimeText) {
-                            let filtered = newGoalTimeText.filter { $0.isNumber }
-                            if filtered != newGoalTimeText {
-                                newGoalTimeText = filtered
+                            let digitsOnly = newGoalTimeText.filter { $0.isNumber }
+                            if digitsOnly.count > 2 {
+                                newGoalTimeText = String(digitsOnly.prefix(2))
+                            } else if digitsOnly != newGoalTimeText {
+                                newGoalTimeText = digitsOnly
                             }
-                            if let time = Int(filtered) {
+                            if let time = Int(newGoalTimeText) {
                                 goalTime = time
                             }
                         }

--- a/NoMyeolmang/NoMyeolmang/Sources/Presentation/TimerSettingView/View/PersonalTimerSettingView.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Presentation/TimerSettingView/View/PersonalTimerSettingView.swift
@@ -29,7 +29,7 @@ struct PersonalTimerSettingView: View {
             Text("10-30분 설정만 가능해요")
                 .textStyle(GSFont.Light12)
                 .foregroundColor(Color("CEB0FF"))
-                .padding(.top, 20)
+                .padding(.top, 24)
             
             Text("시간을 설정해 주세요")
                 .textStyle(GSFont.Regular16)

--- a/NoMyeolmang/NoMyeolmang/Sources/Presentation/TimerSettingView/View/TimerSettingView.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Presentation/TimerSettingView/View/TimerSettingView.swift
@@ -37,7 +37,7 @@ struct TimerSettingView: View {
                     if viewModel.selectedTab == .recommended {
                         FocusTimeSetting(goalTime: $viewModel.goalTime)
                     } else {
-                        PersonalTimerSettingView(goalTime: $viewModel.goalTime)
+                        PersonalTimerSettingView(viewModel: viewModel, goalTime: $viewModel.goalTime)
                     }
                 }
                 .frame(width: 329)

--- a/NoMyeolmang/NoMyeolmang/Sources/Presentation/TimerSettingView/View/TimerSettingView.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Presentation/TimerSettingView/View/TimerSettingView.swift
@@ -15,7 +15,7 @@ struct TimerSettingView: View {
         ZStack {
             Image("SpaceshipBackground")
                 .resizable()
-                .scaledToFill()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .ignoresSafeArea()
                 .allowsHitTesting(false)
         }

--- a/NoMyeolmang/NoMyeolmang/Sources/Presentation/TimerSettingView/View/ToggleTabView.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Presentation/TimerSettingView/View/ToggleTabView.swift
@@ -37,8 +37,11 @@ struct ToggleTabView: View {
                     .contentShape(Rectangle())
                     .onTapGesture {
                         withAnimation {
-                            isRecommendedSelected = .recommended
-                            goalTime = 30
+                            if isRecommendedSelected != .recommended {
+                                isRecommendedSelected = .recommended
+                                goalTime = 30
+                            }
+                            viewModel.validateGoalTime()
                         }
                     }
 
@@ -52,6 +55,7 @@ struct ToggleTabView: View {
                     .onTapGesture {
                         withAnimation {
                             isRecommendedSelected = .personal
+                            viewModel.validateGoalTime()
                         }
                     }
 

--- a/NoMyeolmang/NoMyeolmang/Sources/Presentation/TimerSettingView/ViewModel/TimerSettingViewModel.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Presentation/TimerSettingView/ViewModel/TimerSettingViewModel.swift
@@ -40,7 +40,7 @@ final class TimerSettingViewModel: ObservableObject {
         }
     }
 
-    private func validateGoalTime() {
+    func validateGoalTime() {
         if selectedTab == .recommended {
             isValid = true
         } else {


### PR DESCRIPTION
## ✨ 작업 내용
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #135 

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 텍스트필드 자릿수 제한
- 직접설정 시간설정~분 아래로 내리기
- 입력해놓고 맞춤추천 다녀왔을 때 시간 맞아도버튼 비활성화 되어있음
- 배경화면 가운데 정렬

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="912" height="740" alt="스크린샷 2025-07-30 22 36 15" src="https://github.com/user-attachments/assets/7f4c7eb5-3daf-4a9b-a646-8800d31ccbd7" />



---

## ✅ 체크리스트

예시)
- [x] 관련 이슈를 닫는 커밋 메시지 사용 (`Closes #`)
- [x] 동작 확인 완료 (시뮬레이터 / 실기기)
- [x] PR 제목, 설명 명확히 작성됨
- [x] 커밋 메시지 규칙 준수
- [x] 불필요한 주석/코드 제거

---

## 💬 리뷰 포인트
<!-- 로직 고민, UI 구성, 네이밍 등 의견 요청 -->
직접입력에서 시간 설정 후 맞춤추천으로 이동 후 직접입력으로 이동 시 숫자 사라짐 인지중