### PR TITLE
Bug: #149 팝오버 뷰 폰트 크기, 컴포넌트 간격, 타이머세팅 시간 제한

### DIFF
--- a/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverFeedback/FeedbackPopoverView.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverFeedback/FeedbackPopoverView.swift
@@ -19,7 +19,7 @@ struct FeedbackPopoverView: View {
     }
 
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             VStack {
                 Text("얼마나 몰입했는지 알려주세요")
                     .textStyle(GSFont.SemiBold14)
@@ -32,7 +32,7 @@ struct FeedbackPopoverView: View {
                     .foregroundStyle(Color.white)
                     .padding(.top, 4)
             }
-            .padding(.top, 38)
+            .padding(.top, 32)
 
             PopoverRatingButton(
                 selectedIndex: $selectedIndex,

--- a/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverFeedback/FeedbackPopoverView.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverFeedback/FeedbackPopoverView.swift
@@ -25,13 +25,12 @@ struct FeedbackPopoverView: View {
                     .textStyle(GSFont.SemiBold14)
                     .foregroundStyle(Color.white)
 
-                VStack {
-                    Text("입력해주신 값은 집중력을 더 정확하게")
-                    Text("파악하기 위해서 쓰여요.")
-                }
-                .foregroundStyle(Color.white)
-                .font(.custom("Pretendard-Regular", size: 10))
-                .padding(.top, 4)
+                Text("입력해주신 값은 집중력을 더 정확하게\n파악하기 위해서 쓰여요.")
+                    .fixedSize(horizontal: false, vertical: true)
+                    .textStyle(GSFont.Regular12)
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(Color.white)
+                    .padding(.top, 4)
             }
             .padding(.top, 38)
 

--- a/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverReport/PopoverReportTimeView.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverReport/PopoverReportTimeView.swift
@@ -19,7 +19,7 @@ struct PopoverReportTimeView: View {
             .multilineTextAlignment(.center)
             .foregroundStyle(Color.white)
             .textStyle(GSFont.SemiBold14)
-            .padding(.bottom, 25)
+            .padding(.bottom, 28)
         
             VStack {
                 Text("탐사 시간")

--- a/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverReport/PopoverReportTimeView.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverReport/PopoverReportTimeView.swift
@@ -14,16 +14,16 @@ struct PopoverReportTimeView: View {
     var body: some View {
         VStack {
             VStack {
-                Text("\(goalTime)분간 몰입해서")
-                Text("탐사한 시간만 담았어요")
+                Text("\(goalTime)분간 몰입해서\n탐사한 시간만 담았어요")
             }
+            .multilineTextAlignment(.center)
             .foregroundStyle(Color.white)
             .textStyle(GSFont.SemiBold14)
             .padding(.bottom, 25)
         
             VStack {
                 Text("탐사 시간")
-                    .textStyle(GSFont.Light12)
+                    .textStyle(GSFont.Regular14)
                     .foregroundStyle(Color.white)
                     .padding(.bottom, 4)
                 

--- a/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverReport/PopoverReportTimeView.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverReport/PopoverReportTimeView.swift
@@ -13,19 +13,18 @@ struct PopoverReportTimeView: View {
     
     var body: some View {
         VStack {
-            VStack {
-                Text("\(goalTime)분간 몰입해서\n탐사한 시간만 담았어요")
-            }
-            .multilineTextAlignment(.center)
-            .foregroundStyle(Color.white)
-            .textStyle(GSFont.SemiBold14)
-            .padding(.bottom, 28)
+            Text("\(goalTime)분간 몰입해서\n탐사한 시간만 담았어요")
+                .fixedSize(horizontal: false, vertical: true)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(Color.white)
+                .textStyle(GSFont.SemiBold14)
+                .padding(.bottom, 28)
         
-            VStack {
+            VStack(spacing: 0) {
                 Text("탐사 시간")
                     .textStyle(GSFont.Regular14)
                     .foregroundStyle(Color.white)
-                    .padding(.bottom, 4)
+                    .padding(.bottom, 3)
                 
                 Text(focusTime)
                     .foregroundStyle(Color.white)

--- a/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverReport/ReportPopoverView.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverReport/ReportPopoverView.swift
@@ -12,14 +12,15 @@ struct ReportPopoverView: View {
     @ObservedObject var viewModel: ReportViewModel
     
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             PopoverReportTimeView(
                 goalTime: viewModel.maxDistance,
                 focusTime: viewModel.focusTime
             )
-                .padding(.bottom, 42)
+            .padding(.top, 32)
+            .padding(.bottom, 42)
             
-            VStack {
+            VStack(spacing: 0) {
                 Button {
                     coordinator.push(.timer)
                 } label: {
@@ -35,7 +36,9 @@ struct ReportPopoverView: View {
                         .modifier(PopoverButtonModifier())
                 }
                 .buttonStyle(.plain)
+                .padding(.top, 5)
             }
+            .padding(.bottom, 20)
         }
         .modifier(PopoverBgModifier())
         .onAppear {

--- a/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverReport/ReportPopoverView.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverReport/ReportPopoverView.swift
@@ -18,7 +18,6 @@ struct ReportPopoverView: View {
                 focusTime: viewModel.focusTime
             )
             .padding(.top, 32)
-            .padding(.bottom, 42)
             
             VStack(spacing: 0) {
                 Button {
@@ -38,6 +37,7 @@ struct ReportPopoverView: View {
                 .buttonStyle(.plain)
                 .padding(.top, 5)
             }
+            .padding(.top, 42)
             .padding(.bottom, 20)
         }
         .modifier(PopoverBgModifier())

--- a/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverSetting/PopoverTimerSettingView.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverSetting/PopoverTimerSettingView.swift
@@ -25,7 +25,7 @@ struct PopoverTimerSettingView: View {
         VStack {
             if selectedTab == .recommended {
                 Text("반복 학습에 적합한 시간")
-                    .textStyle(GSFont.Regular12)
+                    .textStyle(GSFont.Regular14)
                     .foregroundStyle(Color.white)
                     .padding(.bottom, 4)
                 
@@ -34,7 +34,7 @@ struct PopoverTimerSettingView: View {
                     .foregroundStyle(Color.white)
             } else {
                 Text("시간을 입력해 주세요")
-                    .textStyle(GSFont.Regular12)
+                    .textStyle(GSFont.Regular14)
                     .foregroundStyle(Color.white)
                     .padding(.bottom, 4)
                 

--- a/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverSetting/PopoverTimerSettingView.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverSetting/PopoverTimerSettingView.swift
@@ -12,15 +12,6 @@ struct PopoverTimerSettingView: View {
     @Binding var goalTime: Int
     @State private var timeInputText: String = ""
     
-    private var numberFormatter: NumberFormatter {
-            let formatter = NumberFormatter()
-            formatter.numberStyle = .decimal
-            formatter.allowsFloats = false
-            formatter.minimum = 10
-            formatter.maximum = 30
-            return formatter
-        }
-    
     var body: some View {
         VStack {
             if selectedTab == .recommended {
@@ -42,11 +33,30 @@ struct PopoverTimerSettingView: View {
                     TextField("", text: $timeInputText)
                         .onChange(of: timeInputText) {
                             let filtered = timeInputText.filter { $0.isNumber }
-                            if filtered != timeInputText {
-                                timeInputText = filtered
+                            let limitedText = String(filtered.prefix(2))
+                            
+                            if let time = Int(limitedText) {
+                                if time > 30 {
+                                    goalTime = 30
+                                    timeInputText = "30"
+                                } else if time == 0 {
+                                    goalTime = 10
+                                    timeInputText = "10"
+                                } else {
+                                    goalTime = time
+                                    if limitedText != timeInputText {
+                                        timeInputText = limitedText
+                                    }
+                                }
+                            } else {
+                                goalTime = 0
+                                timeInputText = ""
                             }
-                            if let time = Int(filtered) {
-                                goalTime = time
+                        }
+                        .onDisappear {
+                            if goalTime < 10 && goalTime != 0 {
+                                goalTime = 10
+                                timeInputText = "10"
                             }
                         }
                         .textStyle(GSFont.SemiBold24)

--- a/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverSetting/PopoverToggleView.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverSetting/PopoverToggleView.swift
@@ -31,7 +31,7 @@ struct PopoverToggleView: View {
                 } label: {
                     Text("맞춤 추천")
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .font(.custom("Pretendard-SemiBold", size: 10))
+                        .textStyle(GSFont.SemiBold12)
                         .foregroundStyle(Color.white)
                         .contentShape(Rectangle())
                 }
@@ -43,7 +43,7 @@ struct PopoverToggleView: View {
                 } label: {
                     Text("직접 설정")
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .font(.custom("Pretendard-SemiBold", size: 10))
+                        .textStyle(GSFont.SemiBold12)
                         .foregroundStyle(Color.white)
                         .contentShape(Rectangle())
                 }

--- a/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverSetting/SettingPopoverView.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverSetting/SettingPopoverView.swift
@@ -13,6 +13,10 @@ struct SettingPopoverView: View {
 
     @State private var selectedTab: TabType = .recommended
     @State private var goalTime: Int = 30
+    
+    var isGoalTimeValid: Bool {
+        (10...30).contains(goalTime)
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -41,6 +45,7 @@ struct SettingPopoverView: View {
                 Text("다음으로")
                     .modifier(PopoverButtonModifier())
             }
+            .disabled(!isGoalTimeValid)
             .buttonStyle(.plain)
             .padding(.top, 60)
             .padding(.bottom, 20)

--- a/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverSetting/SettingPopoverView.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverSetting/SettingPopoverView.swift
@@ -15,7 +15,7 @@ struct SettingPopoverView: View {
     @State private var goalTime: Int = 30
 
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             PopoverToggleView(
                 selectedTab: $selectedTab,
                 onTabSelected: { tab in
@@ -24,13 +24,12 @@ struct SettingPopoverView: View {
                 }
             )
             .padding(.top, 16)
-            .padding(.bottom, 57)
 
             PopoverTimerSettingView(
                 selectedTab: selectedTab,
                 goalTime: $goalTime
             )
-            .padding(.bottom, 65)
+            .padding(.top, 58)
 
             Button {
                 // 팝오버에서 입력한 값만 viewModel에 반영
@@ -43,6 +42,7 @@ struct SettingPopoverView: View {
                     .modifier(PopoverButtonModifier())
             }
             .buttonStyle(.plain)
+            .padding(.top, 60)
             .padding(.bottom, 20)
         }
         .modifier(PopoverBgModifier())

--- a/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverTimer/PopoverTimeLeftView.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverTimer/PopoverTimeLeftView.swift
@@ -13,7 +13,7 @@ struct PopoverTimeLeftView: View {
     var body: some View {
         VStack {
             Text("남은 시간")
-                .textStyle(GSFont.Light12)
+                .textStyle(GSFont.Regular14)
                 .foregroundStyle(Color.white)
                 .padding(.bottom, 4)
             

--- a/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverTimer/PopoverTimeLeftView.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverTimer/PopoverTimeLeftView.swift
@@ -11,7 +11,7 @@ struct PopoverTimeLeftView: View {
     let remainingTime: String
     
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             Text("남은 시간")
                 .textStyle(GSFont.Regular14)
                 .foregroundStyle(Color.white)

--- a/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverTimer/TimerPopoverView.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Presentation/Popover/PopoverTimer/TimerPopoverView.swift
@@ -12,15 +12,15 @@ struct TimerPopoverView: View {
     @ObservedObject var viewModel: TimerViewModel
     
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             Spacer()
             PopoverTimeLeftView(remainingTime: viewModel.formattedTime)
             PopoverTimerStopButton {
                 viewModel.stopSession()
                 coordinator.replaceLast(with: .timerSetting)
             }
-            .padding(.top, 60)
-            .padding(.bottom, 20)
+            .padding(.top, 65)
+            .padding(.bottom, 30)
         }
         .modifier(PopoverBgModifier())
     }


### PR DESCRIPTION
## 📌 PR 제목 형식
[타입] 간단한 설명 (ex. [Feat] 로그인 페이지 레이아웃 구현)

## ✨ 작업 내용
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #149 

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 팝오버 뷰 전반 폰트 크기 수정
- 팝오버 뷰 전반 컴포넌트 간격 수정
- PopoverTimerSettingView에서 사용자 입력 숫자 제한

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->
<img width="302" height="352" alt="스크린샷 2025-07-31 오전 2 08 33" src="https://github.com/user-attachments/assets/e930cc27-c1a9-44e5-81c3-1d652d6a89b7" />
<img width="302" height="353" alt="스크린샷 2025-07-31 오전 2 09 19" src="https://github.com/user-attachments/assets/e8ec7caf-eeb8-4b35-8bfa-96ccf333ec3e" />
<img width="302" height="352" alt="스크린샷 2025-07-31 오전 2 09 49" src="https://github.com/user-attachments/assets/fa35a226-9b09-478b-8cb9-2bdda7ad3938" />
<img width="302" height="352" alt="스크린샷 2025-07-31 오전 2 09 57" src="https://github.com/user-attachments/assets/3bb97e0b-21ea-4d10-8f5d-1e877fe7adbc" />





---

## ✅ 체크리스트

- [x] 관련 이슈를 닫는 커밋 메시지 사용 (`Closes #`)
- [x] 동작 확인 완료 (시뮬레이터 / 실기기)
- [x] PR 제목, 설명 명확히 작성됨
- [x] 커밋 메시지 규칙 준수
- [x] 불필요한 주석/코드 제거

---

## 💬 리뷰 포인트
<!-- 로직 고민, UI 구성, 네이밍 등 의견 요청 -->
- 폰트 자간, 사이즈 디자인과 일치하도록 바꿔두었습니다.
- PopoverTimerSettingView에서 사용자에게 입력을 받아 타이머를 세팅하는 텍스트필드 입력에 제한을 두었습니다. 필터링과 글자수 제한을 걸었고, 30을 초과하는 수를 적으면 강제로 30으로 회귀하도록 구현하였습니다. 30 초과, 10 미만의 경우 다음 하면으로 넘어가는 버튼이 비활성화되도록 하였습니다. 아래 영상에서 확인해보실 수 있습니다.


https://github.com/user-attachments/assets/44dd2350-df7a-46c7-a383-01500cc079a6

