### PR TITLE
Refactor: #168 Sendable 호환을 위한 UserTrainingData 모델 분리

### DIFF
--- a/NoMyeolmang/NoMyeolmang/Sources/App/NoMyeolmangApp.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/App/NoMyeolmangApp.swift
@@ -2,7 +2,7 @@
 //  NoMyeolmangApp.swift
 //  NoMyeolmang
 //
-//  Updated by Moo on 7/29/25.
+//  Updated by Moo on 9/07/25.
 //
 
 import SwiftData
@@ -27,7 +27,7 @@ struct NoMyeolmangApp: App {
 
     var modelContainer: ModelContainer = {
         do {
-            return try ModelContainer(for: UserTrainingData.self)
+            return try ModelContainer(for: UserTrainingDataModel.self)
         } catch {
             fatalError("Could not create ModelContainer: \(error)")
         }

--- a/NoMyeolmang/NoMyeolmang/Sources/Data/SwiftDataUserTrainingDataRepository.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Data/SwiftDataUserTrainingDataRepository.swift
@@ -35,7 +35,8 @@ final class SwiftDataUserTrainingDataRepository: UserTrainingDataRepository {
     }
 
     func write(input data: [UserTrainingData]) async throws -> Bool {
-        data.forEach { context.insert($0) }
+        let models = data.map { $0.toModel() }
+        models.forEach { context.insert($0) }
         do {
             try context.save()
             return true
@@ -48,7 +49,8 @@ final class SwiftDataUserTrainingDataRepository: UserTrainingDataRepository {
     func fetch(count: Int) async throws -> [UserTrainingData] {
         let descriptor = makeFetchDescriptor(fetchLimit: count)
         do {
-            return try context.fetch(descriptor)
+            let models = try context.fetch(descriptor)
+            return models.map { $0.toSendable() }
         } catch {
             print("Fetch error: \(error)")
             throw error
@@ -82,11 +84,11 @@ final class SwiftDataUserTrainingDataRepository: UserTrainingDataRepository {
     }
     
     private func makeFetchDescriptor(
-        predicate: Predicate<UserTrainingData>? = nil,
-        sortBy: [SortDescriptor<UserTrainingData>] = [SortDescriptor(\.createdAt, order: .reverse)],
+        predicate: Predicate<UserTrainingDataModel>? = nil,
+        sortBy: [SortDescriptor<UserTrainingDataModel>] = [SortDescriptor(\.createdAt, order: .reverse)],
         fetchLimit: Int? = nil
-    ) -> FetchDescriptor<UserTrainingData> {
-        var descriptor = FetchDescriptor<UserTrainingData>(
+    ) -> FetchDescriptor<UserTrainingDataModel> {
+        var descriptor = FetchDescriptor<UserTrainingDataModel>(
             predicate: predicate,
             sortBy: sortBy
         )

--- a/NoMyeolmang/NoMyeolmang/Sources/Data/SwiftDataUserTrainingDataRepository.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/Data/SwiftDataUserTrainingDataRepository.swift
@@ -17,6 +17,9 @@ import SwiftData
 /// ``UserTrainingData`` 객체들에 대한 생성, 조회, 업데이트, 삭제 작업을 제공합니다.
 /// 저장된 행동 패턴 데이터는 ``FocusPersonalizater``에서 모델 개인화 학습에 활용됩니다.
 ///
+/// Swift 6 동시성 안전성을 위해 ``UserTrainingData`` (Sendable)와 ``UserTrainingDataModel`` (@Model) 간 
+/// 자동 변환을 수행합니다. 외부에서는 Sendable 구조체만 사용하고, 내부적으로 SwiftData 클래스로 변환합니다.
+///
 /// > Note: 모든 데이터베이스 작업은 비동기적으로 수행되며, 에러 발생 시 적절한 예외를 throw합니다.
 ///
 /// ## Topics

--- a/NoMyeolmang/NoMyeolmang/Sources/ML/Models/UserTrainingData.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/ML/Models/UserTrainingData.swift
@@ -2,7 +2,7 @@
 //  UserTrainingData.swift
 //  NoMyeolmang
 //
-//  Updated by Moo on 7/25/25.
+//  Updated by Moo on 9/07/25.
 //
 
 import Foundation
@@ -13,8 +13,8 @@ import SwiftData
 /// 머신러닝 모델의 개인화 학습을 위한 사용자 피드백 데이터를 저장합니다.
 ///
 /// `UserTrainingData`는 ``FocusPersonalizater/run(from:)`` 메서드의 입력으로 사용되어 
-/// 모델 개인화 학습을 수행합니다. @Model 매크로를 통해 SwiftData에 자동 저장되며, 
-/// ``features`` 속성의 ``Features`` 데이터와 함께 ``predictedScore``(모델 예측값)와 
+/// 모델 개인화 학습을 수행합니다. Sendable 프로토콜을 준수하여 동시성 환경에서 
+/// 안전하게 사용할 수 있으며, ``features`` 속성의 ``Features`` 데이터와 함께 ``predictedScore``(모델 예측값)와 
 /// ``userScore``(실제 사용자 평가)를 비교하여 학습에 활용됩니다.
 ///
 /// ### Creating Training Data
@@ -27,8 +27,16 @@ import SwiftData
 /// - ``predictedScore``
 /// - ``userScore``
 /// - ``createdAt``
+
+struct UserTrainingData: Sendable {
+    let features: Features
+    let predictedScore: Double
+    let userScore: Double
+    let createdAt: Date
+}
+
 @Model
-final class UserTrainingData: Sendable {
+final class UserTrainingDataModel {
     var features: Features
     var predictedScore: Double
     var userScore: Double
@@ -44,5 +52,27 @@ final class UserTrainingData: Sendable {
         self.predictedScore = predictedScore
         self.userScore = userScore
         self.createdAt = createdAt
+    }
+}
+
+extension UserTrainingData {
+    func toModel() -> UserTrainingDataModel {
+        UserTrainingDataModel(
+            features: features,
+            predictedScore: predictedScore,
+            userScore: userScore,
+            createdAt: createdAt
+        )
+    }
+}
+
+extension UserTrainingDataModel {
+    func toSendable() -> UserTrainingData {
+        UserTrainingData(
+            features: features,
+            predictedScore: predictedScore,
+            userScore: userScore,
+            createdAt: createdAt
+        )
     }
 }

--- a/NoMyeolmang/NoMyeolmang/Sources/ML/Models/UserTrainingData.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/ML/Models/UserTrainingData.swift
@@ -10,23 +10,12 @@ import SwiftData
 
 /// # ``timé/UserTrainingData``
 ///
-/// 머신러닝 모델의 개인화 학습을 위한 사용자 피드백 데이터를 저장합니다.
+/// ML 서비스용 Sendable 구조체입니다.
 ///
-/// `UserTrainingData`는 ``FocusPersonalizater/run(from:)`` 메서드의 입력으로 사용되어 
-/// 모델 개인화 학습을 수행합니다. Sendable 프로토콜을 준수하여 동시성 환경에서 
-/// 안전하게 사용할 수 있으며, ``features`` 속성의 ``Features`` 데이터와 함께 ``predictedScore``(모델 예측값)와 
-/// ``userScore``(실제 사용자 평가)를 비교하여 학습에 활용됩니다.
+/// ``FocusPersonalizater/run(from:)`` 메서드의 입력으로 사용되어 모델 개인화 학습을 수행합니다.
+/// Swift 6 동시성 안전성을 위해 ``UserTrainingDataModel`` (SwiftData 저장용)과 분리되었습니다.
 ///
-/// ### Creating Training Data
-///
-/// - ``init(features:predictedScore:userScore:createdAt:)``
-///
-/// ### Inspecting Training Data
-///
-/// - ``features``
-/// - ``predictedScore``
-/// - ``userScore``
-/// - ``createdAt``
+/// > Note: Repository에서 자동으로 ``UserTrainingDataModel``로 변환하여 저장합니다.
 
 struct UserTrainingData: Sendable {
     let features: Features
@@ -35,6 +24,10 @@ struct UserTrainingData: Sendable {
     let createdAt: Date
 }
 
+/// SwiftData 저장용 @Model 클래스입니다.
+///
+/// ``UserTrainingData``와 동일한 데이터를 포함하지만 SwiftData 요구사항에 맞춰 mutable 프로퍼티를 가집니다.
+/// Repository 내부에서만 사용합니다.
 @Model
 final class UserTrainingDataModel {
     var features: Features
@@ -55,7 +48,10 @@ final class UserTrainingDataModel {
     }
 }
 
+// MARK: - Model Conversion Extensions
+
 extension UserTrainingData {
+    /// SwiftData 저장을 위해 UserTrainingDataModel로 변환합니다.
     func toModel() -> UserTrainingDataModel {
         UserTrainingDataModel(
             features: features,
@@ -67,6 +63,7 @@ extension UserTrainingData {
 }
 
 extension UserTrainingDataModel {
+    /// Sendable UserTrainingData 구조체로 변환합니다.
     func toSendable() -> UserTrainingData {
         UserTrainingData(
             features: features,

--- a/NoMyeolmang/NoMyeolmang/Sources/ML/Services/FocusScorePredictor.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/ML/Services/FocusScorePredictor.swift
@@ -34,7 +34,7 @@ final class FocusScorePredictor: Predictor {
 
     func run(from features: Features) -> UserTrainingData {
         let predictedScore = predict(features: features) ?? 0.0
-        return UserTrainingData(features: features, predictedScore: predictedScore, userScore: 0.0)
+        return UserTrainingData(features: features, predictedScore: predictedScore, userScore: 0.0, createdAt: Date())
     }
 
     private func makeModelInputArray(features: Features) -> MLMultiArray? {


### PR DESCRIPTION
## ✨ 작업 내용
### 📌 관련 이슈 (Related Issue)
- Closes #168

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

### Why?
- @Model 클래스의 mutable 프로퍼티가 Sendable 프로토콜과 충돌
- 동시성 환경에서 UserTrainingData 사용 시 컴파일 경고 발생

### What?
기존 SwitData 모델을 분리해서 적용시킴.
- UserTrainingData: ML 서비스용 Sendable 구조체
- UserTrainingDataModel: SwiftData 저장용 @Model 클래스