### PR TITLE
Refactor: #173 MinMaxScaler 중복 코드 개선 및 타입 추가

### DIFF
--- a/NoMyeolmang/NoMyeolmang/Sources/ML/Models/FeatureType.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/ML/Models/FeatureType.swift
@@ -1,0 +1,47 @@
+//
+//  FeatureType.swift
+//  timé
+//
+//  Created by Muchan Kim on 9/7/25.
+//
+
+enum FeatureType {
+    case shortBlink
+    case longBlink
+    case face
+    case phone
+    case yawn
+    case elapsedTime
+}
+
+typealias MinMaxRange = (min: Double, max: Double)
+
+extension FeatureType {
+    var range: MinMaxRange {
+        switch self {
+        case .shortBlink:
+            return (Constants.blinkCountPerMinValue, Constants.blinkCounterPerMaxValue)
+        case .longBlink:
+            return (Constants.longBlinkCountPerMinValue, Constants.longBlinkCounterPerMaxValue)
+        case .face:
+            return (Constants.faceBodyPresentMinValue, Constants.faceBodyPresentMaxValue)
+        case .phone:
+            return (Constants.phonePresentMinValue, Constants.phonePresentMaxValue)
+        case .yawn:
+            return (Constants.yawnCountPerMinValue, Constants.yawnCounterPerMaxValue)
+        case .elapsedTime:
+            return (Constants.elapsedTimeMinValue, Constants.elapsedTimeMaxValue)
+        }
+    }
+}
+
+extension FeatureType {
+    var isNeedClip: Bool {
+        switch self {
+        case .shortBlink, .longBlink, .yawn:
+            return true
+        case .face, .phone, .elapsedTime:
+            return false
+        }
+    }
+}

--- a/NoMyeolmang/NoMyeolmang/Sources/ML/Services/FocusPersonalizater.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/ML/Services/FocusPersonalizater.swift
@@ -108,35 +108,16 @@ final class FocusPersonalizater: Personalizater {
         }
         return (input: inputArray, label: labelArray)
     }
-
+    
+    // TODO: FocusScorePredictor랑 네이밍 통일 필요
     private func makeInputMultiArray(data: Features) -> MLMultiArray? {
-        guard
-            let inputArray = try? MLMultiArray(
-                shape: [1, 6],
-                dataType: .float32
-            )
-        else {
+        let scaledValues = MinMaxScaler.scale(data)
+        guard let inputArray = try? MLMultiArray(shape: [1, 6], dataType: .float32) else {
             return nil
         }
-
-        inputArray[0] = NSNumber(
-            value: MinMaxScaler.scaleBlink(data.blinkCountPerMin)
-        )
-        inputArray[1] = NSNumber(
-            value: MinMaxScaler.scaleFace(data.faceBodyPresent)
-        )
-        inputArray[2] = NSNumber(
-            value: MinMaxScaler.scalePhone(data.phonePresent)
-        )
-        inputArray[3] = NSNumber(
-            value: MinMaxScaler.scaleTime(data.elapsedTime)
-        )
-        inputArray[4] = NSNumber(
-            value: MinMaxScaler.scaleYawn(data.yawnPerMin)
-        )
-        inputArray[5] = NSNumber(
-            value: MinMaxScaler.scaleLongBlink(data.longBlinkPerMin)
-        )
+        for (index, value) in scaledValues.enumerated() {
+            inputArray[index] = NSNumber(value: value)
+        }
         return inputArray
     }
 

--- a/NoMyeolmang/NoMyeolmang/Sources/ML/Services/FocusScorePredictor.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/ML/Services/FocusScorePredictor.swift
@@ -38,14 +38,11 @@ final class FocusScorePredictor: Predictor {
     }
 
     private func makeModelInputArray(features: Features) -> MLMultiArray? {
+        let scaledValues = MinMaxScaler.scale(features)
         guard let inputArray = try? MLMultiArray(shape: [1, 6], dataType: .float32) else { return nil }
-
-        inputArray[0] = NSNumber(value: MinMaxScaler.scaleBlink(features.blinkCountPerMin))
-        inputArray[1] = NSNumber(value: MinMaxScaler.scaleFace(features.faceBodyPresent))
-        inputArray[2] = NSNumber(value: MinMaxScaler.scalePhone(features.phonePresent))
-        inputArray[3] = NSNumber(value: MinMaxScaler.scaleTime(features.elapsedTime))
-        inputArray[4] = NSNumber(value: MinMaxScaler.scaleYawn(features.yawnPerMin))
-        inputArray[5] = NSNumber(value: MinMaxScaler.scaleLongBlink(features.longBlinkPerMin))
+        for (index, value) in scaledValues.enumerated() {
+            inputArray[index] = NSNumber(value: value)
+        }
         return inputArray
     }
 

--- a/NoMyeolmang/NoMyeolmang/Sources/ML/Utilities/MinMaxScaler.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/ML/Utilities/MinMaxScaler.swift
@@ -10,72 +10,52 @@
 /// 특성 데이터를 0-1 범위로 정규화하는 스케일링 유틸리티를 제공합니다.
 ///
 /// `MinMaxScaler`는 각 행동 특성을 머신러닝 모델에 적합한 0-1 범위로 변환합니다.
-/// 범위를 벗어나는 값들은 `softClip`을 통해 안전하게 처리되며, 분모가 0인 경우를 
-/// 방지하는 안전한 스케일링 로직을 포함합니다. 모든 스케일링은 ``Constants``에서 
-/// 정의된 최솟값과 최댓값을 기준으로 수행되며, ``FocusScorePredictor``와 
+/// 범위를 벗어나는 값들은 `clip`을 통해 안전하게 처리되며, 분모가 0인 경우를
+/// 방지하는 안전한 스케일링 로직을 포함합니다. 모든 스케일링은 ``FeatureType``에서
+/// 정의된 최솟값과 최댓값을 기준으로 수행되며, ``FocusScorePredictor``와
 /// ``FocusPersonalizater``에서 ``Features`` 데이터 전처리에 사용됩니다.
 ///
-///
+import CoreML
+
 enum MinMaxScaler {
-    static func scaleBlink(_ value: Double) -> Double {
-        return safeScale(
-            value: value,
-            min: Constants.blinkCountPerMinValue,
-            max: Constants.blinkCounterPerMaxValue
-        )
+    /// Features 객체의 모든 특성을 정규화하여 배열로 반환합니다.
+    ///
+    /// 이 메서드는 ``Features``의 6가지 특성을 각각의 ``FeatureType``에 맞게
+    /// 0-1 범위로 정규화합니다. 클리핑이 필요한 특성은 자동으로 안전하게 처리됩니다.
+    ///
+    /// - Parameter features: 정규화할 특성 데이터
+    /// - Returns: 정규화된 값들의 배열 (순서: blink, face, phone, time, yawn, longBlink)
+    static func scale(_ features: Features) -> [Double] {
+        return [
+            scaleValue(value: features.blinkCountPerMin, for: .shortBlink),
+            scaleValue(value: features.faceBodyPresent, for: .face),
+            scaleValue(value: features.phonePresent, for: .phone),
+            scaleValue(value: features.elapsedTime, for: .elapsedTime),
+            scaleValue(value: features.yawnPerMin, for: .yawn),
+            scaleValue(value: features.longBlinkPerMin, for: .longBlink)
+        ]
+    }
+    
+    private static func scaleValue(value: Double, for featureType: FeatureType) -> Double {
+        let (min, max) = featureType.range
+        if featureType.isNeedClip {
+            return safeScale(value: value, min: min, max: max)
+        } else {
+            return normalize(value: value, min: min, max: max)
+        }
     }
 
-    static func scaleFace(_ value: Double) -> Double {
-        return scale(
-            value: value,
-            min: Constants.faceBodyPresentMinValue,
-            max: Constants.faceBodyPresentMaxValue
-        )
-    }
-
-    static func scalePhone(_ value: Double) -> Double {
-        return scale(
-            value: value,
-            min: Constants.phonePresentMinValue,
-            max: Constants.phonePresentMaxValue
-        )
-    }
-
-    static func scaleTime(_ value: Double) -> Double {
-        return scale(
-            value: value,
-            min: Constants.elapsedTimeMinValue,
-            max: Constants.elapsedTimeMaxValue
-        )
-    }
-
-    static func scaleYawn(_ value: Double) -> Double {
-        return safeScale(
-            value: value,
-            min: Constants.yawnCountPerMinValue,
-            max: Constants.yawnCounterPerMaxValue
-        )
-    }
-
-    static func scaleLongBlink(_ value: Double) -> Double {
-        return safeScale(
-            value: value,
-            min: Constants.longBlinkCountPerMinValue,
-            max: Constants.longBlinkCounterPerMaxValue
-        )
-    }
-
-    private static func scale(value: Double, min: Double, max: Double) -> Double {
+    private static func normalize(value: Double, min: Double, max: Double) -> Double {
         guard max != min else { return 0.0 }
         return (value - min) / (max - min)
     }
 
-    private static func softClip(value: Double, min: Double, max: Double) -> Double {
+    private static func clip(value: Double, between min: Double, and max: Double) -> Double {
         return Swift.max(min, Swift.min(value, max))
     }
 
     private static func safeScale(value: Double, min: Double, max: Double) -> Double {
-        let clippedValue = softClip(value: value, min: min, max: max)
-        return scale(value: clippedValue, min: min, max: max)
+        let clippedValue = clip(value: value, between: min, and: max)
+        return normalize(value: clippedValue, min: min, max: max)
     }
 }

--- a/NoMyeolmang/NoMyeolmang/Sources/ML/Utilities/MinMaxScaler.swift
+++ b/NoMyeolmang/NoMyeolmang/Sources/ML/Utilities/MinMaxScaler.swift
@@ -14,9 +14,6 @@
 /// 방지하는 안전한 스케일링 로직을 포함합니다. 모든 스케일링은 ``FeatureType``에서
 /// 정의된 최솟값과 최댓값을 기준으로 수행되며, ``FocusScorePredictor``와
 /// ``FocusPersonalizater``에서 ``Features`` 데이터 전처리에 사용됩니다.
-///
-import CoreML
-
 enum MinMaxScaler {
     /// Features 객체의 모든 특성을 정규화하여 배열로 반환합니다.
     ///


### PR DESCRIPTION
## ✨ 작업 내용
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #173

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- FeatureType Enum 추가
- MinMaxScaler 불필요한 중복 코드 제거 및 Scale 메서드 변경. 
scale 메서드는 기존에 단일 스케일만 제공해줬습니다. 이로 인해 사용되는 ML모듈에서 불필요한 책임을 가지게 되고, 코드가 길어졌습니다.
변경된 scale 메서드는 Feature 타입을 받아서 전체 스케일링을 적용한 [Double]을 반환합니다. 